### PR TITLE
[Issue #4]: using synthetic column names in join results and clean logs.

### DIFF
--- a/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsColumnHandle.java
+++ b/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsColumnHandle.java
@@ -132,6 +132,15 @@ public final class PixelsColumnHandle implements ColumnHandle
         return new ColumnMetadata(columnName, columnType);
     }
 
+    /**
+     * @return the synthetic column name that can be used in joins or aggregations.
+     * It is composed of columnName_logicalOrdinal.
+     */
+    public String getSynthColumnName()
+    {
+        return this.columnName + "_" + this.logicalOrdinal;
+    }
+
     @Override
     public int hashCode()
     {

--- a/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsPageSourceProvider.java
+++ b/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsPageSourceProvider.java
@@ -170,7 +170,7 @@ public class PixelsPageSourceProvider implements ConnectorPageSourceProvider
         output.setAccessKey(config.getMinioAccessKey());
         output.setSecretKey(config.getMinioSecretKey());
         output.setEndpoint(config.getMinioEndpoint());
-        logger.info("join input: " + JSON.toJSONString(joinInput));
+        // logger.info("join input: " + JSON.toJSONString(joinInput));
         CompletableFuture<JoinOutput> joinOutputFuture;
         if (inputSplit.getJoinAlgo() == JoinAlgorithm.BROADCAST_CHAIN)
         {


### PR DESCRIPTION
By using synthetic column names in the join results, different tables can have the same column name and will not conflict.