### PR TITLE
[Issue #4]: wait for the completion of the previous stage in a join.

### DIFF
--- a/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsPageSourceProvider.java
+++ b/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsPageSourceProvider.java
@@ -117,7 +117,10 @@ public class PixelsPageSourceProvider implements ConnectorPageSourceProvider
                 // perform aggregation push down.
                 MinIO.ConfigMinIO(config.getMinioEndpoint(), config.getMinioAccessKey(), config.getMinioSecretKey());
                 Storage storage = StorageFactory.Instance().getStorage(Storage.Scheme.minio);
-                IntermediateFileCleaner.Instance().registerStorage(storage);
+                if (config.isCleanLocalResult())
+                {
+                    IntermediateFileCleaner.Instance().registerStorage(storage);
+                }
                 return new PixelsPageSource(pixelsSplit, pixelsColumns, storage, cacheFile, indexFile,
                         pixelsFooterCache, getLambdaAggrOutput(pixelsSplit), null);
             }
@@ -126,7 +129,10 @@ public class PixelsPageSourceProvider implements ConnectorPageSourceProvider
                 // perform join push down.
                 MinIO.ConfigMinIO(config.getMinioEndpoint(), config.getMinioAccessKey(), config.getMinioSecretKey());
                 Storage storage = StorageFactory.Instance().getStorage(Storage.Scheme.minio);
-                IntermediateFileCleaner.Instance().registerStorage(storage);
+                if (config.isCleanLocalResult())
+                {
+                    IntermediateFileCleaner.Instance().registerStorage(storage);
+                }
                 return new PixelsPageSource(pixelsSplit, pixelsColumns, storage, cacheFile, indexFile,
                         pixelsFooterCache, getLambdaJoinOutput(pixelsSplit), null);
             }
@@ -146,7 +152,10 @@ public class PixelsPageSourceProvider implements ConnectorPageSourceProvider
                     }
                     MinIO.ConfigMinIO(config.getMinioEndpoint(), config.getMinioAccessKey(), config.getMinioSecretKey());
                     Storage storage = StorageFactory.Instance().getStorage(Storage.Scheme.minio);
-                    IntermediateFileCleaner.Instance().registerStorage(storage);
+                    if (config.isCleanLocalResult())
+                    {
+                        IntermediateFileCleaner.Instance().registerStorage(storage);
+                    }
                     return new PixelsPageSource(pixelsSplit, pixelsColumns, storage, cacheFile, indexFile,
                             pixelsFooterCache, getLambdaScanOutput(pixelsSplit, columnsToRead, projection), null);
                 } else

--- a/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsSplitManager.java
+++ b/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsSplitManager.java
@@ -23,6 +23,7 @@ import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.serializer.SerializerFeature;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.protobuf.InvalidProtocolBufferException;
 import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
 import io.etcd.jetcd.KeyValue;
@@ -209,6 +210,7 @@ public class PixelsSplitManager implements ConnectorSplitManager
                         SerializerFeature[] features = new SerializerFeature[]{SerializerFeature.WriteClassName};
                         String json = JSON.toJSONString(outputCollection, features);
                         logger.info("join outputs: " + json);
+                        logger.info("cumulated duration " + outputCollection.getCumulativeDurationMs());
                     } catch (Exception e)
                     {
                         logger.error(e, "failed to execute the join plan using pixels-lambda");
@@ -261,6 +263,7 @@ public class PixelsSplitManager implements ConnectorSplitManager
                         SerializerFeature[] features = new SerializerFeature[]{SerializerFeature.WriteClassName};
                         String json = JSON.toJSONString(outputCollection, features);
                         logger.info("aggregation outputs: " + json);
+                        logger.info("cumulated duration " + outputCollection.getCumulativeDurationMs());
                     } catch (Exception e)
                     {
                         logger.error(e, "failed to execute the aggregation plan using pixels-lambda");
@@ -463,7 +466,7 @@ public class PixelsSplitManager implements ConnectorSplitManager
         {
             joinEndian = JoinAdvisor.Instance().getJoinEndian(leftTable, rightTable);
             joinAlgo = JoinAdvisor.Instance().getJoinAlgorithm(leftTable, rightTable, joinEndian);
-        } catch (MetadataException e)
+        } catch (MetadataException | InvalidProtocolBufferException e)
         {
             logger.error("failed to get join algorithm", e);
             throw new TrinoException(PixelsErrorCode.PIXELS_METASTORE_ERROR, e);

--- a/connector/src/main/java/io/pixelsdb/pixels/trino/impl/PixelsTrinoConfig.java
+++ b/connector/src/main/java/io/pixelsdb/pixels/trino/impl/PixelsTrinoConfig.java
@@ -51,6 +51,7 @@ public class PixelsTrinoConfig
 
     private String pixelsConfig = null;
     private boolean lambdaEnabled = false;
+    private boolean cleanLocalResult = true;
     private int localScanConcurrency = -1;
     private String minioOutputFolder = null;
     private String minioEndpointIP = null;
@@ -149,6 +150,13 @@ public class PixelsTrinoConfig
         return this;
     }
 
+    @Config("clean.local.result")
+    public PixelsTrinoConfig setCleanLocalResult(boolean cleanLocalResult)
+    {
+        this.cleanLocalResult = cleanLocalResult;
+        return this;
+    }
+
     @Config("local.scan.concurrency")
     public PixelsTrinoConfig setLocalScanConcurrency(int concurrency)
     {
@@ -202,6 +210,11 @@ public class PixelsTrinoConfig
     public int getLocalScanConcurrency()
     {
         return localScanConcurrency;
+    }
+
+    public boolean isCleanLocalResult()
+    {
+        return cleanLocalResult;
     }
 
     @NotNull

--- a/connector/src/main/resources/pixels.properties
+++ b/connector/src/main/resources/pixels.properties
@@ -10,6 +10,7 @@ pixels.config=/home/pixels/opt/pixels/pixels.properties
 # serverless config
 lambda.enabled=false
 local.scan.concurrency=40
+clean.local.result=true
 minio.output.folder=pixels-lambda/output/
 minio.endpoint.port=9000
 minio.access.key=lambda


### PR DESCRIPTION
1. wait for the completion of the previous stage in a join.
2. make clean local result files configurable.