### PR TITLE
[PIXELS-385]: only load HDFS when initializing connector.

### DIFF
--- a/connector/src/main/java/io/pixelsdb/pixels/trino/impl/PixelsTrinoConfig.java
+++ b/connector/src/main/java/io/pixelsdb/pixels/trino/impl/PixelsTrinoConfig.java
@@ -118,7 +118,11 @@ public class PixelsTrinoConfig
                  *
                  * I currently don't know the reason (08.27.2021).
                  */
-                StorageFactory.Instance().reload();
+                if (StorageFactory.Instance().isEnabled(Storage.Scheme.hdfs))
+                {
+                    // PIXELS-385: only reload HDFS if it is enabled.
+                    StorageFactory.Instance().reload(Storage.Scheme.hdfs);
+                }
             } catch (IOException e)
             {
                 throw new TrinoException(PixelsErrorCode.PIXELS_STORAGE_ERROR, e);


### PR DESCRIPTION
The other Storage, such as MinIO is not configured when the connector is initialized by Trino, hence the loading will fail.