### PR TITLE
[PIXELS-506] set the scan bytes to transaction properties

### DIFF
--- a/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsConnector.java
+++ b/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsConnector.java
@@ -142,7 +142,7 @@ public class PixelsConnector implements Connector
             executorType = ExecutorType.PENDING;
         }
 
-        return new PixelsTransactionHandle(context.getTransId(), context.getTimestamp(), executorType);
+        return new PixelsTransactionHandle(context.getTransId(), context.getTimestamp(), readOnly, executorType);
     }
 
     @Override
@@ -153,9 +153,12 @@ public class PixelsConnector implements Connector
             PixelsTransactionHandle handle = (PixelsTransactionHandle) transactionHandle;
             try
             {
-                // PIXELS-506: set scan bytes in transaction context, it will be used for the calculation of billed cents.
-                this.transService.setTransProperty(handle.getTransId(), Constants.TRANS_CONTEXT_SCAN_BYTES_KEY,
-                        String.valueOf(((PixelsTransactionHandle) transactionHandle).getScanBytes()));
+                if (handle.isReadOnly())
+                {
+                    // PIXELS-506: set scan bytes in transaction context, it will be used for the calculation of billed cents.
+                    this.transService.setTransProperty(handle.getTransId(), Constants.TRANS_CONTEXT_SCAN_BYTES_KEY,
+                            String.valueOf(handle.getScanBytes()));
+                }
                 this.transService.commitTrans(handle.getTransId(), handle.getTimestamp());
             } catch (TransException e)
             {

--- a/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsConnector.java
+++ b/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsConnector.java
@@ -173,7 +173,7 @@ public class PixelsConnector implements Connector
         } else
         {
             throw new TrinoException(PixelsErrorCode.PIXELS_TRANS_HANDLE_TYPE_ERROR,
-                    "The transaction handle is not an instance of PixelsTransactionHandle.");
+                    "the transaction handle is not an instance of PixelsTransactionHandle");
         }
     }
 
@@ -206,7 +206,7 @@ public class PixelsConnector implements Connector
         } else
         {
             throw new TrinoException(PixelsErrorCode.PIXELS_TRANS_HANDLE_TYPE_ERROR,
-                    "The transaction handle is not an instance of PixelsTransactionHandle.");
+                    "the transaction handle is not an instance of PixelsTransactionHandle");
         }
     }
 
@@ -221,7 +221,7 @@ public class PixelsConnector implements Connector
         } catch (InterruptedException e)
         {
             throw new TrinoException(PixelsErrorCode.PIXELS_STORAGE_ERROR,
-                    "Failed to clean intermediate path for the query");
+                    "failed to clean intermediate path for the query");
         }
     }
 

--- a/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsConnector.java
+++ b/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsConnector.java
@@ -158,6 +158,7 @@ public class PixelsConnector implements Connector
                 // PIXELS-506: set scan bytes in transaction context, it will be used for the calculation of billed cents.
                 this.transService.setTransProperty(handle.getTransId(), Constants.TRANS_CONTEXT_SCAN_BYTES_KEY,
                         String.valueOf(handle.getScanBytes()));
+                logger.info("----------------scan bytes in connector: " + handle.getScanBytes() + "trans is read only: " + handle.isReadOnly());
                 this.transService.commitTrans(handle.getTransId(), handle.getTimestamp());
             } catch (TransException e)
             {

--- a/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsConnector.java
+++ b/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsConnector.java
@@ -158,7 +158,6 @@ public class PixelsConnector implements Connector
                 // PIXELS-506: set scan bytes in transaction context, it will be used for the calculation of billed cents.
                 this.transService.setTransProperty(handle.getTransId(), Constants.TRANS_CONTEXT_SCAN_BYTES_KEY,
                         String.valueOf(handle.getScanBytes()));
-                logger.info("----------------scan bytes in connector: " + handle.getScanBytes() + "trans is read only: " + handle.isReadOnly());
                 this.transService.commitTrans(handle.getTransId(), handle.getTimestamp());
             } catch (TransException e)
             {

--- a/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsConnector.java
+++ b/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsConnector.java
@@ -27,6 +27,7 @@ import io.pixelsdb.pixels.common.transaction.TransContext;
 import io.pixelsdb.pixels.common.transaction.TransService;
 import io.pixelsdb.pixels.common.turbo.ExecutorType;
 import io.pixelsdb.pixels.common.turbo.QueryScheduleService;
+import io.pixelsdb.pixels.common.utils.Constants;
 import io.pixelsdb.pixels.trino.exception.PixelsErrorCode;
 import io.pixelsdb.pixels.trino.impl.PixelsMetadataProxy;
 import io.pixelsdb.pixels.trino.impl.PixelsTrinoConfig;
@@ -152,6 +153,9 @@ public class PixelsConnector implements Connector
             PixelsTransactionHandle handle = (PixelsTransactionHandle) transactionHandle;
             try
             {
+                // PIXELS-506: set scan bytes in transaction context, it will be used for the calculation of billed cents.
+                this.transService.setTransProperty(handle.getTransId(), Constants.TRANS_CONTEXT_SCAN_BYTES_KEY,
+                        String.valueOf(((PixelsTransactionHandle) transactionHandle).getScanBytes()));
                 this.transService.commitTrans(handle.getTransId(), handle.getTimestamp());
             } catch (TransException e)
             {

--- a/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsConnector.java
+++ b/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsConnector.java
@@ -142,6 +142,8 @@ public class PixelsConnector implements Connector
             executorType = ExecutorType.PENDING;
         }
 
+        // readOnly in Trino is false if not explicitly set.
+        // Do not use it to identify whether a transaction is an analytic query.
         return new PixelsTransactionHandle(context.getTransId(), context.getTimestamp(), readOnly, executorType);
     }
 
@@ -153,12 +155,9 @@ public class PixelsConnector implements Connector
             PixelsTransactionHandle handle = (PixelsTransactionHandle) transactionHandle;
             try
             {
-                if (handle.isReadOnly())
-                {
-                    // PIXELS-506: set scan bytes in transaction context, it will be used for the calculation of billed cents.
-                    this.transService.setTransProperty(handle.getTransId(), Constants.TRANS_CONTEXT_SCAN_BYTES_KEY,
-                            String.valueOf(handle.getScanBytes()));
-                }
+                // PIXELS-506: set scan bytes in transaction context, it will be used for the calculation of billed cents.
+                this.transService.setTransProperty(handle.getTransId(), Constants.TRANS_CONTEXT_SCAN_BYTES_KEY,
+                        String.valueOf(handle.getScanBytes()));
                 this.transService.commitTrans(handle.getTransId(), handle.getTimestamp());
             } catch (TransException e)
             {

--- a/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsMetadata.java
+++ b/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsMetadata.java
@@ -408,7 +408,7 @@ public class PixelsMetadata implements ConnectorMetadata
         try
         {
             boolean res = this.metadataProxy.createSchema(schemaName);
-            if (res == false)
+            if (!res)
             {
                 throw  new TrinoException(PixelsErrorCode.PIXELS_SQL_EXECUTE_ERROR,
                         "Schema " + schemaName + " already exists.");
@@ -425,7 +425,7 @@ public class PixelsMetadata implements ConnectorMetadata
         try
         {
             boolean res = this.metadataProxy.dropSchema(schemaName);
-            if (res == false)
+            if (!res)
             {
                 throw  new TrinoException(PixelsErrorCode.PIXELS_SQL_EXECUTE_ERROR,
                         "Schema " + schemaName + " does not exist.");

--- a/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsPageSource.java
+++ b/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsPageSource.java
@@ -448,14 +448,14 @@ class PixelsPageSource implements ConnectorPageSource
             return;
         }
 
+        closed = true;
+
         closeReader();
 
         if (this.localSplitCounter != null)
         {
             this.localSplitCounter.decrementAndGet();
         }
-
-        closed = true;
     }
 
     /**
@@ -465,6 +465,11 @@ class PixelsPageSource implements ConnectorPageSource
     {
         try
         {
+            if (closed)
+            {
+                return;
+            }
+
             if (pixelsReader != null)
             {
                 if (recordReader != null)

--- a/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsPageSource.java
+++ b/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsPageSource.java
@@ -377,10 +377,6 @@ class PixelsPageSource implements ConnectorPageSource
             {
                 do
                 {
-                    if (this.closed)
-                    {
-                        break;
-                    }
                     rowBatch = recordReader.readBatch(BatchSize, false);
                     if (rowBatch.size <= 0)
                     {

--- a/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsPageSource.java
+++ b/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsPageSource.java
@@ -377,6 +377,10 @@ class PixelsPageSource implements ConnectorPageSource
             {
                 do
                 {
+                    if (this.closed)
+                    {
+                        break;
+                    }
                     rowBatch = recordReader.readBatch(BatchSize, false);
                     if (rowBatch.size <= 0)
                     {

--- a/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsPageSource.java
+++ b/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsPageSource.java
@@ -366,8 +366,8 @@ class PixelsPageSource implements ConnectorPageSource
         }
 
         this.batchId++;
-        VectorizedRowBatch rowBatch;
-        int rowBatchSize;
+        VectorizedRowBatch rowBatch = null;
+        int rowBatchSize = 0;
 
         Block[] blocks = new Block[this.numColumnToRead];
 

--- a/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsTransactionHandle.java
+++ b/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsTransactionHandle.java
@@ -43,7 +43,7 @@ public class PixelsTransactionHandle implements ConnectorTransactionHandle
      * The accumulative data size in bytes scanned by this transaction (query).
      * This field is not serialized and is only used to calculate the scan size in the coordinator.
      */
-    private AtomicDouble scanSize;
+    private final AtomicDouble scanBytes;
 
     /**
      * Create a transaction handle.
@@ -59,7 +59,7 @@ public class PixelsTransactionHandle implements ConnectorTransactionHandle
         this.transId = transId;
         this.timestamp = timestamp;
         this.executorType = executorType;
-        this.scanSize = new AtomicDouble(0);
+        this.scanBytes = new AtomicDouble(0);
     }
 
     @JsonProperty
@@ -85,13 +85,13 @@ public class PixelsTransactionHandle implements ConnectorTransactionHandle
         this.executorType = executorType;
     }
 
-    public void addScanSize(double columnSize)
+    public void addScanBytes(double columnSize)
     {
-        this.scanSize.addAndGet(columnSize);
+        this.scanBytes.addAndGet(columnSize);
     }
 
-    public double getScanSize()
+    public double getScanBytes()
     {
-        return this.scanSize.get();
+        return this.scanBytes.get();
     }
 }

--- a/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsTransactionHandle.java
+++ b/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsTransactionHandle.java
@@ -36,6 +36,10 @@ public class PixelsTransactionHandle implements ConnectorTransactionHandle
      */
     private final long timestamp;
     /**
+     * Whether the transaction is read only.
+     */
+    private final boolean readOnly;
+    /**
      * The type of executor to execute this query.
      */
     private ExecutorType executorType;
@@ -49,15 +53,18 @@ public class PixelsTransactionHandle implements ConnectorTransactionHandle
      * Create a transaction handle.
      * @param transId the transaction id of the query, which is a single-statement read-only transaction.
      * @param timestamp the timestamp of a transaction.
+     * @param readOnly true if the transaction is read only.
      * @param executorType the type of executor to execute this query.
      */
     @JsonCreator
     public PixelsTransactionHandle(@JsonProperty("transId") long transId,
                                    @JsonProperty("timestamp") long timestamp,
+                                   @JsonProperty("readOnly") boolean readOnly,
                                    @JsonProperty("executorType") ExecutorType executorType)
     {
         this.transId = transId;
         this.timestamp = timestamp;
+        this.readOnly = readOnly;
         this.executorType = executorType;
         this.scanBytes = new AtomicDouble(0);
     }
@@ -72,6 +79,12 @@ public class PixelsTransactionHandle implements ConnectorTransactionHandle
     public long getTimestamp()
     {
         return this.timestamp;
+    }
+
+    @JsonProperty
+    public boolean isReadOnly()
+    {
+        return this.readOnly;
     }
 
     @JsonProperty

--- a/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsTransactionHandle.java
+++ b/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsTransactionHandle.java
@@ -21,6 +21,7 @@ package io.pixelsdb.pixels.trino;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.util.concurrent.AtomicDouble;
 import io.pixelsdb.pixels.common.turbo.ExecutorType;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 
@@ -38,6 +39,11 @@ public class PixelsTransactionHandle implements ConnectorTransactionHandle
      * The type of executor to execute this query.
      */
     private ExecutorType executorType;
+    /**
+     * The accumulative data size in bytes scanned by this transaction (query).
+     * This field is not serialized and is only used to calculate the scan size in the coordinator.
+     */
+    private AtomicDouble scanSize;
 
     /**
      * Create a transaction handle.
@@ -53,6 +59,7 @@ public class PixelsTransactionHandle implements ConnectorTransactionHandle
         this.transId = transId;
         this.timestamp = timestamp;
         this.executorType = executorType;
+        this.scanSize = new AtomicDouble(0);
     }
 
     @JsonProperty
@@ -76,5 +83,15 @@ public class PixelsTransactionHandle implements ConnectorTransactionHandle
     public void setExecutorType(ExecutorType executorType)
     {
         this.executorType = executorType;
+    }
+
+    public void addScanSize(double columnSize)
+    {
+        this.scanSize.addAndGet(columnSize);
+    }
+
+    public double getScanSize()
+    {
+        return this.scanSize.get();
     }
 }

--- a/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsTransactionHandle.java
+++ b/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsTransactionHandle.java
@@ -26,9 +26,6 @@ import io.trino.spi.connector.ConnectorTransactionHandle;
 
 public class PixelsTransactionHandle implements ConnectorTransactionHandle
 {
-    public static final PixelsTransactionHandle Default = new PixelsTransactionHandle(
-            -1, -1, ExecutorType.PENDING);
-
     /**
      * transId is the transaction id of the query, which is a single-statement read-only transaction.
      */

--- a/listener/pom.xml
+++ b/listener/pom.xml
@@ -38,6 +38,30 @@
             <optional>true</optional>
         </dependency>
 
+        <!-- protobuf -->
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- grpc -->
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty-shaded</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-stub</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>

--- a/listener/src/main/java/io/pixelsdb/pixels/trino/PixelsEventListener.java
+++ b/listener/src/main/java/io/pixelsdb/pixels/trino/PixelsEventListener.java
@@ -138,7 +138,6 @@ public class PixelsEventListener implements EventListener
             try
             {
                 long inputBytes = queryCompletedEvent.getStatistics().getPhysicalInputBytes();
-                logger.info("+++++++++++++++++++++ scan size in listener: " + inputBytes);
                 this.transService.setTransProperty(externalTraceId.get(),
                         Constants.TRANS_CONTEXT_SCAN_BYTES_KEY, String.valueOf(inputBytes));
             } catch (TransException e)

--- a/listener/src/main/java/io/pixelsdb/pixels/trino/PixelsEventListener.java
+++ b/listener/src/main/java/io/pixelsdb/pixels/trino/PixelsEventListener.java
@@ -138,6 +138,7 @@ public class PixelsEventListener implements EventListener
             try
             {
                 long inputBytes = queryCompletedEvent.getStatistics().getPhysicalInputBytes();
+                logger.info("+++++++++++++++++++++ scan size in listener: " + inputBytes);
                 this.transService.setTransProperty(externalTraceId.get(),
                         Constants.TRANS_CONTEXT_SCAN_BYTES_KEY, String.valueOf(inputBytes));
             } catch (TransException e)


### PR DESCRIPTION
Collect the scan byte in transaction commit and query completion event, respectively, and set it into the properties in the transaction context.