### PR TITLE
[PIXELS-647] fix aggregation output path

### DIFF
--- a/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsSplitManager.java
+++ b/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsSplitManager.java
@@ -348,7 +348,7 @@ public class PixelsSplitManager implements ConnectorSplitManager
                 {
                     OutputInfo output = aggrInput.getOutput();
                     output.setStorageInfo(config.getOutputStorageInfo());
-                    output.setPath(config.getOutputFolderForQuery(transHandle.getTransId(),
+                    output.setPath(config.getOutputFilePathForQuery(transHandle.getTransId(),
                             output.getPath().substring(output.getPath().indexOf(tableHandle.getSchemaName()))));
                     aggrInput.setOutput(output);
                     PixelsSplit split = new PixelsSplit(

--- a/connector/src/main/java/io/pixelsdb/pixels/trino/impl/PixelsTrinoConfig.java
+++ b/connector/src/main/java/io/pixelsdb/pixels/trino/impl/PixelsTrinoConfig.java
@@ -258,6 +258,27 @@ public class PixelsTrinoConfig
     }
 
     /**
+     * Get the output file path for a transaction (query). It will not end with a slash '/'.
+     * @param transId the transaction id of the query
+     * @param post the postfix to be appended to the end of the file path
+     * @return the output file path
+     */
+    public String getOutputFilePathForQuery(long transId, String post)
+    {
+        if (this.cloudFunctionSwitch == CloudFunctionSwitch.OFF)
+        {
+            throw new TrinoException(PixelsErrorCode.PIXELS_STORAGE_ERROR,
+                    new Throwable("should not use output storage when cloud function is turned off"));
+        }
+        if (post.endsWith("/"))
+        {
+            throw new TrinoException(PixelsErrorCode.PIXELS_STORAGE_ERROR,
+                    "the file path postfix should not end with as slash '/'");
+        }
+        return this.outputFolder + transId + (post.startsWith("/") ? "" : "/") + post;
+    }
+
+    /**
      * Get the intermediate folder for a transaction (query). It will end with
      * a slash '/', hence there is no need to add a slash manually.
      * @param transId the transaction id of the query


### PR DESCRIPTION
Previously, we added a slash '/' at the end of the output path of the final aggregation inputs. This is incorrect and causes the Trino works unable to read the aggregation output file (because it is considered as a folder).