### PR TITLE
[Issue #132] modify the error message when the listening schema is empty

### DIFF
--- a/listener/src/main/java/io/pixelsdb/pixels/trino/PixelsEventListener.java
+++ b/listener/src/main/java/io/pixelsdb/pixels/trino/PixelsEventListener.java
@@ -186,7 +186,7 @@ public class PixelsEventListener implements EventListener
 
         if (queryCompletedEvent.getContext().getSchema().isEmpty())
         {
-            logger.error("can not write log in pixels event listener");
+            logger.warn("listener schema is empty");
             logger.info("query id: " + queryId + ", user: " + user);
             return;
         }


### PR DESCRIPTION
Using warn instead.

<img width="1484" alt="截屏2025-03-24 17 02 37" src="https://github.com/user-attachments/assets/c107b532-e7e9-44fc-90a7-87a7be4ec5a9" />
