### PR TITLE
[Issue #138] fix error: under certain startup sequences, the cache cannot obtain the new version

### DIFF
--- a/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsSplitManager.java
+++ b/connector/src/main/java/io/pixelsdb/pixels/trino/PixelsSplitManager.java
@@ -99,8 +99,8 @@ public class PixelsSplitManager implements ConnectorSplitManager
     private final boolean cacheEnabled;
     private final boolean multiSplitForOrdered;
     private final boolean projectionReadEnabled;
-    private final String cacheSchema;
-    private final String cacheTable;
+    private String cacheSchema;
+    private String cacheTable;
     private final int fixedSplitSize;
 
     @Inject
@@ -854,6 +854,18 @@ public class PixelsSplitManager implements ConnectorSplitManager
         boolean usingCache = false;
         if (this.cacheEnabled)
         {
+            KeyValue keyValue = EtcdUtil.Instance().getKeyValue(Constants.LAYOUT_VERSION_LITERAL);
+            if (keyValue != null)
+            {
+                String value = keyValue.getValue().toString(StandardCharsets.UTF_8);
+                // PIXELS-636: get schema and table name from etcd instead of config file.
+                String[] splits = value.split(":");
+                checkArgument(splits.length == 2, "invalid value for key '" +
+                        Constants.LAYOUT_VERSION_LITERAL + "' in etcd: " + value);
+                SchemaTableName schemaTableName = new SchemaTableName(splits[0]);
+                this.cacheSchema = schemaTableName.getSchemaName();
+                this.cacheTable = schemaTableName.getTableName();
+            }
             if (schemaName.equalsIgnoreCase(this.cacheSchema) &&
                     tableName.equalsIgnoreCase(this.cacheTable))
             {


### PR DESCRIPTION
fix error:    Cache cannot acquire the new version when following the sequence of starting Trino first, then triggering cache version changes in ETCD.